### PR TITLE
feat(box-config) default to two workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ environment variables:
 | --------------- | ------------------------------------------------------------------------- | --------- |
 | `KONG_VERSION`  | the Kong version number to download and install at the provision step     | `0.11.1`  |
 | `KONG_VB_MEM`   | virtual machine memory (RAM) size *(in MB)*                               | `2048`    |
+| `KONG_VB_CPUS`  | the number of CPUs available to the virtual machine                       | `2`       |
 | `KONG_CASSANDRA`| the major Cassandra version to use, either `2` or `3`                     | `3`, or `2` for Kong versions `9.x` and older |
 | `KONG_PATH`     | the path to mount your local Kong source under the guest's `/kong` folder | `./kong`, `../kong`, or nothing. In this order. |
 | `KONG_PLUGIN_PATH` | the path to mount your local plugin source under the guest's `/kong-plugin` folder | `./kong-plugin`, `../kong-plugin`, or nothing. In this order. |

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ environment variables:
 | --------------- | ------------------------------------------------------------------------- | --------- |
 | `KONG_VERSION`  | the Kong version number to download and install at the provision step     | `0.11.1`  |
 | `KONG_VB_MEM`   | virtual machine memory (RAM) size *(in MB)*                               | `2048`    |
-| `KONG_VB_CPUS`  | the number of CPUs available to the virtual machine                       | `2`       |
+| `KONG_VB_CPUS`  | the number of CPUs available to the virtual machine (relates to the number of nginx workers) | `2`       |
 | `KONG_CASSANDRA`| the major Cassandra version to use, either `2` or `3`                     | `3`, or `2` for Kong versions `9.x` and older |
 | `KONG_PATH`     | the path to mount your local Kong source under the guest's `/kong` folder | `./kong`, `../kong`, or nothing. In this order. |
 | `KONG_PLUGIN_PATH` | the path to mount your local plugin source under the guest's `/kong-plugin` folder | `./kong-plugin`, `../kong-plugin`, or nothing. In this order. |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     memory = 2048
   end
 
+  if ENV["KONG_VB_CPUS"]
+    cpus = ENV["KONG_VB_CPUS"]
+  else
+    cpus = 2
+  end
+
   if ENV["KONG_VERSION"]
     version = ENV["KONG_VERSION"]
   else
@@ -65,7 +71,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider :virtualbox do |vb|
    vb.name = "vagrant_kong"
    vb.memory = memory
-   vb.cpus = 2
+   vb.cpus = cpus
   end
 
   config.vm.box = "ubuntu/trusty64"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,6 +65,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider :virtualbox do |vb|
    vb.name = "vagrant_kong"
    vb.memory = memory
+   vb.cpus = 2
   end
 
   config.vm.box = "ubuntu/trusty64"


### PR DESCRIPTION
Provide a default for vb.cpus that enables Kong to start with multiple
workers. This more closely mimics a Kong node running in production
and increases the chances for developers to discover concurrency bugs
before issuing a PR.

Default is set to two under the assumption that most developers have
a multi-cpu machine these days. VirtualBox will silently start with
a value of one, effectively reverting to the behavior we have today.

Tested on Mac only.