### PR TITLE
copy host setting into vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,11 +259,13 @@ environment variables:
 | --------------- | ------------------------------------------------------------------------- | --------- |
 | `KONG_VERSION`  | the Kong version number to download and install at the provision step     | `0.11.2`  |
 | `KONG_VB_MEM`   | virtual machine memory (RAM) size *(in MB)*                               | `2048`    |
-| `KONG_VB_CPUS`  | the number of CPUs available to the virtual machine (relates to the number of nginx workers) | `2`       |
 | `KONG_CASSANDRA`| the major Cassandra version to use, either `2` or `3`                     | `3`, or `2` for Kong versions `9.x` and older |
 | `KONG_PATH`     | the path to mount your local Kong source under the guest's `/kong` folder | `./kong`, `../kong`, or nothing. In this order. |
 | `KONG_PLUGIN_PATH` | the path to mount your local plugin source under the guest's `/kong-plugin` folder | `./kong-plugin`, `../kong-plugin`, or nothing. In this order. |
 | `KONG_PROFILING` | boolean determining whether or not to build systemtap and friends tools   | undefined |
+| `KONG_NGINX_WORKER_PROCESSES`  | the number of CPUs available to the virtual machine (relates to the number of nginx workers) | `2` |
+| `KONG_LOG_LEVEL`  | setting the `KONG_LOG_LEVEL` variable in the virtual machine | none |
+| n.a.  | setting the `KONG_PREFIX` variable in the virtual machine | `/kong/servroot` when the Kong source tree is mounted at `/kong` in the vm. |
 
 Use them when provisioning, e.g.:
 ```shell

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,8 +32,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     memory = 2048
   end
 
-  if ENV["KONG_VB_CPUS"]
-    cpus = ENV["KONG_VB_CPUS"]
+  if ENV["KONG_NGINX_WORKER_PROCESSES"]
+    cpus = ENV["KONG_NGINX_WORKER_PROCESSES"]
   else
     cpus = 2
   end
@@ -74,6 +74,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     anreports = ""
   end
 
+  if ENV["KONG_LOG_LEVEL"]
+    loglevel = ENV["KONG_LOG_LEVEL"]
+  else
+    loglevel = ""
+  end
+
   config.vm.provider :virtualbox do |vb|
    vb.name = "vagrant_kong"
    vb.memory = memory
@@ -95,5 +101,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 8444, host: 8444
 
   config.vm.provision "shell", path: "provision.sh",
-    :args => [version, cversion, profiling, anreports]
+    :args => [version, cversion, profiling, anreports, loglevel]
 end

--- a/provision.sh
+++ b/provision.sh
@@ -6,6 +6,8 @@ KONG_VERSION=$1
 CASSANDRA_VERSION=$2
 KONG_PROFILING=$3
 ANREPORTS=$4
+LOGLEVEL=$5
+
 if [ "$CASSANDRA_VERSION" = "2" ]; then
    CASSANDRA_VERSION=2.2.8
 else
@@ -87,7 +89,7 @@ then
   # 0.10.3 and earlier are on Github
   echo "failed downloading from BinTray, trying Github..."
   set -o errexit
-  wget -q -O kong.deb https://github.com/Mashape/kong/releases/download/$KONG_VERSION/kong-$KONG_VERSION.precise_all.deb
+  wget -q -O kong.deb https://github.com/Kong/kong/releases/download/$KONG_VERSION/kong-$KONG_VERSION.precise_all.deb
 fi
 set -o errexit
 
@@ -155,9 +157,17 @@ echo "export PATH=\$PATH:/usr/local/bin:/usr/local/openresty/bin:/opt/stap/bin:/
 # do the same for root so we access to profiling tools
 echo "export PATH=\$PATH:/usr/local/bin:/usr/local/openresty/bin:/opt/stap/bin:/usr/local/stapxx:/usr/local/openresty/nginx/sbin" >> /root/.bashrc
 
-# copy host setting
+# copy host settings
+if [ -n "$LOGLEVEL" ]; then
+  echo "export KONG_LOG_LEVEL=$LOGLEVEL" >> /home/vagrant/.bashrc
+fi
 if [ -n "$ANREPORTS" ]; then
   echo "export KONG_ANONYMOUS_REPORTS=$ANREPORTS" >> /home/vagrant/.bashrc
+fi
+
+# set prefix (working directory) to the source tree if available (same as Kong test suite)
+if [ -d "/kong" ]; then
+  echo "export KONG_PREFIX=/kong/servroot" >> /home/vagrant/.bashrc
 fi
 
 # Adjust LUA_PATH to find the plugin dev setup


### PR DESCRIPTION
Copies host setting for cpus/processes, log level, and auto sets the prefix.

1. removes `KONG_VB_CPUS` optional environment variable, instead it uses the standard kong one called `KONG_NGINX_WORKER_PROCESSES` which is slightly different but solved the exact same problem. Provisioning will now use the `KONG_NGINX_WORKER_PROCESSES` variable, or otherwise the default of `2` to set the number of cpus.
1. the `KONG_LOG_LEVEL` variable will be copied from the host into the vm when provisioning.
1. the `KONG_PREFIX` in the vm will be set to `/kong/servroot`, which means it will be accessible from the host system where it is located at `<Kong repo>/servroot`, the same location where the tests run.

The idea of this change is to make it easier to rebuild the vagrant box, by specifying the settings in the users bash profile on the host machine.

Setting 2 and 3 interfere with the tests, this has been fixed in https://github.com/Kong/kong/pull/3066 .
