### PR TITLE
fix(provision) make admin listen on all interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ on Kong or on custom plugins.
 * [Known issues](#known-issues)
 * [Enterprise support](#enterprise-support)
 
+**IMPORTANT**: The Kong admin api is by default only available on localhost,
+but to be able to access it from the host system, the Vagrant box will listen
+on all interfaces by default. This might be a security risk in your environment.
 
 ## Testing Kong
 

--- a/provision.sh
+++ b/provision.sh
@@ -170,6 +170,10 @@ if [ -d "/kong" ]; then
   echo "export KONG_PREFIX=/kong/servroot" >> /home/vagrant/.bashrc
 fi
 
+# set admin listen addresses
+echo "export KONG_ADMIN_LISTEN=0.0.0.0:8001" >> /home/vagrant/.bashrc
+echo "export KONG_ADMIN_LISTEN_SSL=0.0.0.0:8444" >> /home/vagrant/.bashrc
+
 # Adjust LUA_PATH to find the plugin dev setup
 echo "export LUA_PATH=\"/kong-plugin/?.lua;/kong-plugin/?/init.lua;;\"" >> /home/vagrant/.bashrc
 


### PR DESCRIPTION
Kong 0.12 switched to listen on localhost only by default. This
prevents the access to the admin api from the host machine.
We override it by listening on all interfaces again.