### PR TITLE
add libssl-dev to APT packages list

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -106,7 +106,7 @@ echo "*************************************************************************"
 sudo apt-get install -y httpie jq
 
 #Installing required dependencies
-sudo apt-get install -y git curl make pkg-config unzip apt-transport-https language-pack-en
+sudo apt-get install -y git curl make pkg-config unzip apt-transport-https language-pack-en libssl-dev
 
 
 ####################


### PR DESCRIPTION
Following the instructions to set up a development environment eventually leads to this error:

```sh
vagrant@ubuntu-xenial:/kong$ make dev
Checking stability of dependencies in the absence of
kong 0.14.0-0...

Removing kong 0.14.0-0...
Removal successful.
Missing dependencies for kong 0.14.0-0:
   luaossl == 20180708 (20171028-0 installed)

kong 0.14.0-0 depends on luaossl == 20180708 (20171028-0 installed)
Installing https://luarocks.org/luaossl-20180708-0.src.rock

Error: Failed installing dependency: https://luarocks.org/luaossl-20180708-0.src.rock - Could not find header file for CRYPTO
  No file openssl/crypto.h in /usr/include
You may have to install CRYPTO in your system and/or pass CRYPTO_DIR or CRYPTO_INCDIR to the luarocks command.
Example: luarocks install luaossl CRYPTO_DIR=/usr/local
Makefile:19: recipe for target 'dev' failed
make: *** [dev] Error 1
```

Missing openssl headers when attempting to install the `luaossl` dependency.

For some reason this package was removed in this PR:

https://github.com/Kong/kong-vagrant/pull/89

which I believe was a mistake.