### PR TITLE
Enable postgresql service

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -134,6 +134,8 @@ host    all             all             ::1/128                 trust
 host    all             all             0.0.0.0/0               trust
 EOL
 
+sudo systemctl enable postgresql
+
 sudo /etc/init.d/postgresql restart
 
 # Create PG user and database


### PR DESCRIPTION
This auto-starts postgresql on image boot. Right now when the
image is brought down and back up, the DB does not automatically start
on subsequent boots.