### PR TITLE
Error in steps for enviroments in README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,15 @@ $ make dev -i
 
 # only if you want to run the custom plugin, tell Kong to load it
 $ export KONG_PLUGINS=myplugin
+# if you are running Kong < 0.14.0, run this instead:
+# $ export KONG_CUSTOM_PLUGINS=myplugin
 
 # startup kong: while inside '/kong' call `kong` from the repo as `bin/kong`!
 # we will also need to ensure that migrations are up to date
 $ cd /kong
-$ bin/kong migrations up
+$ bin/kong migrations bootstrap
+# if you are running Kong < 0.15.0, run this instead:
+# $ kong start --run-migrations
 $ bin/kong start
 ```
 
@@ -204,11 +208,15 @@ $ vagrant ssh
 
 # only if you want to run the custom plugin, tell Kong to load it
 $ export KONG_PLUGINS=myplugin
+# if you are running Kong < 0.14.0, run this instead:
+# $ export KONG_CUSTOM_PLUGINS=myplugin
 
 # startup kong: while inside '/kong' call `kong` from the repo as `bin/kong`!
 # we will also need to ensure that migrations are up to date
 $ cd /kong
-$ bin/kong migrations up
+$ bin/kong migrations bootstrap
+# if you are running Kong < 0.15.0 in the source repo, run this instead:
+# $ kong start --run-migrations
 $ bin/kong start
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ $ vagrant up
 # ssh into the Vagrant machine, and setup the dev environment
 $ vagrant ssh
 $ cd /kong
-$ make dev -i
+$ make dev
 
 # only if you want to run the custom plugin, tell Kong to load it
 $ export KONG_PLUGINS=myplugin

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ $ vagrant up
 # ssh into the Vagrant machine, and setup the dev environment
 $ vagrant ssh
 $ cd /kong
-$ make dev
+$ make dev -i
 
 # only if you want to run the custom plugin, tell Kong to load it
-$ export KONG_CUSTOM_PLUGINS=myplugin
+$ export KONG_PLUGINS=myplugin
 
 # startup kong: while inside '/kong' call `kong` from the repo as `bin/kong`!
 # we will also need to ensure that migrations are up to date
@@ -177,7 +177,7 @@ specified when building the Vagrant box will lead to unpredictable results.
 $ vagrant ssh
 
 # only if you want to run the custom plugin, tell Kong to load it
-$ export KONG_CUSTOM_PLUGINS=myplugin
+$ export KONG_PLUGINS=myplugin
 
 # startup kong: while inside '/kong' call `kong` from the repo as `bin/kong`!
 # we will also need to ensure that migrations are up to date

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $ cd /kong
 $ make dev
 
 # only if you want to run the custom plugin, tell Kong to load it
-$ export KONG_PLUGINS=myplugin
+$ export KONG_PLUGINS=bundled,myplugin
 # if you are running Kong < 0.14.0, run this instead:
 # $ export KONG_CUSTOM_PLUGINS=myplugin
 
@@ -133,8 +133,8 @@ $ export KONG_PLUGINS=myplugin
 # we will also need to ensure that migrations are up to date
 $ cd /kong
 $ bin/kong migrations bootstrap
-# if you are running Kong < 0.15.0, run this instead:
-# $ kong start --run-migrations
+# if you are running Kong < 0.15.0, run this instead of bootstrap:
+# $ bin/kong migrations up
 $ bin/kong start
 ```
 
@@ -207,16 +207,15 @@ specified when building the Vagrant box will lead to unpredictable results.
 $ vagrant ssh
 
 # only if you want to run the custom plugin, tell Kong to load it
-$ export KONG_PLUGINS=myplugin
+$ export KONG_PLUGINS=bundled,myplugin
 # if you are running Kong < 0.14.0, run this instead:
 # $ export KONG_CUSTOM_PLUGINS=myplugin
 
 # startup kong: while inside '/kong' call `kong` from the repo as `bin/kong`!
-# we will also need to ensure that migrations are up to date
 $ cd /kong
 $ bin/kong migrations bootstrap
-# if you are running Kong < 0.15.0 in the source repo, run this instead:
-# $ kong start --run-migrations
+# if you are running Kong < 0.15.0, run this instead of bootstrap:
+# $ bin/kong migrations up
 $ bin/kong start
 ```
 


### PR DESCRIPTION
docs(conf) fix

When execute the command 'make dev' for setup the dev environment and error occurs when install luasec dependencies.
And the export environment variable for custom plugins its change.(KONG_CUSTOM_PLUGINS -> KONG_PLUGINS).
That error produced a blocking for setup the environment for develop a custom plugin.
