### PR TITLE
chore(*) bump Kong version to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ environment variables:
 
 | name                           | description                                                                                    | default                                                       |
 | ------------------------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `KONG_VERSION`                 | the Kong version number to download and install at the provision step                          | `0.14.1`                                                      |
+| `KONG_VERSION`                 | the Kong version number to download and install at the provision step                          | `1.0.1`                                                       |
 | `KONG_VB_MEM`                  | virtual machine memory (RAM) size *(in MB)*                                                    | `4096`                                                        |
 | `KONG_CASSANDRA`               | the major Cassandra version to use, either `2` or `3`                                          | `3`, or `2` for Kong versions `9.x` and older                 |
 | `KONG_PATH`                    | the path to mount your local Kong source under the guest's `/kong` folder                      | `./kong`, `../kong`, or nothing. In this order.               |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if ENV["KONG_VERSION"]
     version = ENV["KONG_VERSION"]
   else
-    version = "1.0.0"
+    version = "1.0.1"
   end
 
   if ENV["KONG_CASSANDRA"]


### PR DESCRIPTION
### Summary

Bumps Kong from `1.0.0` to `1.0.1`.

PS. if you approve, please merge right away, and delete the branch.