### PR TITLE
Install libyaml-dev for newer Kong versions

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -103,7 +103,7 @@ echo "Installing APT packages"
 echo "*************************************************************************"
 
 if [ $KONG_NUM_VERSION -ge 001500 ]; then
-  sudo -E apt-get install -qq iptables libcap2-bin nmap
+  sudo -E apt-get install -qq iptables libcap2-bin nmap libyaml-dev
 fi
 
 sudo -E apt-get install -qq httpie jq


### PR DESCRIPTION
Requirement introduced in Kong 1.1.0 through dependency on lyaml. 

Could be added in several places... As there is no guarantee that the underlying kong repo is the same version as installed through the provisioning script, I didn't want to introduce a new "if" for this version so decided to just install for 0.15 and above. 

Resolves #110 