### PR TITLE
chore(utilities) bump systemtap version to 4.0

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -216,14 +216,15 @@ if [ -n "$KONG_UTILITIES" ]; then
 
   # Install systemtap: https://openresty.org/en/build-systemtap.html
   sudo -E apt-get install -qq build-essential zlib1g-dev elfutils libdw-dev gettext
-  wget -q http://sourceware.org/systemtap/ftp/releases/systemtap-3.0.tar.gz
-  tar -xf systemtap-3.0.tar.gz
-  cd systemtap-3.0/
-  ./configure --prefix=/opt/stap --disable-docs \
-              --disable-publican --disable-refdocs CFLAGS="-g -O2"
-  make
-  sudo make install
-  rm -rf ./systemtap-3.0 systemtap-3.0.tar.gz
+  wget -q http://sourceware.org/systemtap/ftp/releases/systemtap-4.0.tar.gz
+  tar -xf systemtap-4.0.tar.gz
+  pushd systemtap-4.0/
+    ./configure --prefix=/opt/stap --disable-docs \
+                --disable-publican --disable-refdocs CFLAGS="-g -O2"
+    make
+    sudo make install
+  popd
+  rm -rf ./systemtap-4.0 systemtap-4.0.tar.gz
 
   # Install stapxx and openresty-systemtap-toolkit
   pushd /usr/local


### PR DESCRIPTION
## Summary

Bump SystemTap version to 4.0. `gcc` version in Ubuntu 18.04 base includes some new warnings by default, which breaks the compilation of SystemTap 3.0, unless we manually disable particular compiler checks - e.g., `-Wimplicit-fallthrough=0` - by hand. SystemTap 4.0 fixed the issues making the compiler unhappy. If there are concerns with bumping to 4.0, we can go the compiler flags tuning route.