### PR TITLE
chore(*) bump Kong to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ environment variables:
 
 | name                           | description                                                                                    | default                                                       |
 | ------------------------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `KONG_VERSION`                 | the Kong version number to download and install at the provision step                          | `1.1.2`                                                       |
+| `KONG_VERSION`                 | the Kong version number to download and install at the provision step                          | `1.2.0`                                                       |
 | `KONG_VB_MEM`                  | virtual machine memory (RAM) size *(in MB)*                                                    | `4096`                                                        |
 | `KONG_CASSANDRA`               | the major Cassandra version to use, either `2` or `3`                                          | `3`, or `2` for Kong versions `9.x` and older                 |
 | `KONG_PATH`                    | the path to mount your local Kong source under the guest's `/kong` folder                      | `./kong`, `../kong`, or nothing. In this order.               |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if ENV["KONG_VERSION"]
     version = ENV["KONG_VERSION"]
   else
-    version = "1.1.2"
+    version = "1.2.0"
   end
 
   if ENV["KONG_CASSANDRA"]

--- a/provision.sh
+++ b/provision.sh
@@ -40,7 +40,7 @@ KONG_ADMIN_LISTEN="0.0.0.0:8001"
 KONG_ADMIN_LISTEN_SSL="0.0.0.0:8444"
 
 if [ $KONG_NUM_VERSION -gt 001003 ]; then
-  KONG_DOWNLOAD_URL="https://bintray.com/kong/kong-community-edition-deb/download_file?file_path=dists%2Fkong-community-edition-${KONG_VERSION}.trusty.all.deb"
+  KONG_DOWNLOAD_URL="https://bintray.com/kong/kong-deb/download_file?file_path=kong-${KONG_VERSION}.trusty.all.deb"
 fi
 
 if [ $KONG_NUM_VERSION -ge 001300 ]; then
@@ -51,7 +51,7 @@ fi
 
 if [ $KONG_NUM_VERSION -ge 001500 ]; then
   # use Bionic now instead of Trusty
-  KONG_DOWNLOAD_URL="https://bintray.com/kong/kong-community-edition-deb/download_file?file_path=dists%2Fkong-community-edition-${KONG_VERSION}.bionic.all.deb"
+  KONG_DOWNLOAD_URL="https://bintray.com/kong/kong-deb/download_file?file_path=kong-${KONG_VERSION}.bionic.all.deb"
 
   # Let's enable transparent listening option as well
   KONG_PROXY_LISTEN="0.0.0.0:8000 transparent, 0.0.0.0:8443 transparent ssl"
@@ -170,20 +170,10 @@ sudo -E apt-get install -qq redis-server
 sudo chown vagrant /var/log/redis/redis-server.log
 
 echo "*************************************************************************"
-echo "Installing Java and Cassandra $CASSANDRA_VERSION"
+echo "Installing Cassandra $CASSANDRA_VERSION"
 echo "*************************************************************************"
 
 set +o errexit
-java -version  > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-  echo "Installing Java"
-  echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | sudo -E debconf-set-selections
-  echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 seen true" | sudo -E debconf-set-selections
-  sudo -E add-apt-repository ppa:webupd8team/java
-  sudo -E apt-get update -qq
-  sudo -E apt-get install -qq oracle-java8-installer
-fi
-
 dpkg -f noninteractive --list cassandra > /dev/null 2>&1
 if [ $? -ne 0 ]; then
   echo "Installing Cassandra"


### PR DESCRIPTION
- Updated Kong version to 1.2.0.
- Removed oracle-java8-installer from provision.sh as it is not available after licensing changes.