### PR TITLE
fix(provision) kong package url

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -51,6 +51,17 @@ fi
 
 if [ $KONG_NUM_VERSION -ge 001500 ]; then
   # use Bionic now instead of Trusty
+  KONG_DOWNLOAD_URL="https://bintray.com/kong/kong-deb/download_file?file_path=kong-${KONG_VERSION}.bionic.all.deb"
+
+  # Let's enable transparent listening option as well
+  KONG_PROXY_LISTEN="0.0.0.0:8000 transparent, 0.0.0.0:8443 transparent ssl"
+
+  # Kong 0.15.0 has a stream module, let's enable that too
+  KONG_STREAM_LISTEN="0.0.0.0:9000 transparent"
+fi
+
+if [ $KONG_NUM_VERSION -ge 010300 ]; then
+  # use Bionic now instead of Trusty
   KONG_DOWNLOAD_URL="https://bintray.com/kong/kong-deb/download_file?file_path=kong-${KONG_VERSION}.bionic.amd64.deb"
 
   # Let's enable transparent listening option as well


### PR DESCRIPTION
Fix Kong package download URL in a backward-compatible way. Given arm64 was only introduced with 1.3.0, only packages for Kong versions >= 1.3.0 have the new URL.