### PR TITLE
chore(ci) add travis-ci tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+dist: bionic
+language: python
+
+# Cache the big Vagrant boxes
+cache:
+  directories:
+  - /home/travis/.vagrant.d/boxes
+
+install:
+  # Install libvrt & KVM (see https://github.com/alvistack/ansible-role-virtualbox/blob/master/.travis.yml)
+  - sudo apt-get update && sudo apt-get install -y bridge-utils dnsmasq-base ebtables libvirt-bin libvirt-dev qemu-kvm qemu-utils ruby-dev
+
+  # Download Vagrant & Install Vagrant package
+  - sudo wget -nv https://releases.hashicorp.com/vagrant/2.2.7/vagrant_2.2.7_x86_64.deb
+  - sudo dpkg -i vagrant_2.2.7_x86_64.deb
+
+  # Vagrant correctly installed?
+  - vagrant --version
+
+  # Install vagrant-libvirt Vagrant plugin
+  - sudo vagrant plugin install vagrant-libvirt
+
+script:
+  - sudo vagrant validate
+  - sudo vagrant up --provider=libvirt
+  - sudo vagrant status
+  # Kong is not successfully running but I believe knowing the Vagrantfile is valid and it can provision is beneficial
+  # - sudo vagrant ssh -c "kong version"
+  # - sudo vagrant ssh -c "kong status"
+  # - curl -I localhost:8000

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -87,7 +87,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/ — timesync-set-threshold", 10000]
   end
 
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "generic/ubuntu1904"
 
   if not source == ""
     config.vm.synced_folder source, "/kong"


### PR DESCRIPTION
this does not successfully run Kong

Example failure here: https://travis-ci.com/github/Kong/kong-vagrant/builds/180702282#L1305
![image](https://user-images.githubusercontent.com/697188/90802248-f5a6ed80-e2e4-11ea-8f26-1d9b508a8267.png)

But it does run `vagrant validate` and `vagrant up` which will include the provision script therefore I think this has value