### PR TITLE
Fix example curl command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ $ curl -i -X POST \
 
 $ curl -i -X POST \
   --url http://localhost:8001/services/mockbin/routes \
-  --data 'paths=/'
+  --data 'paths[]=/'
 
 # add the custom plugin, to our new api
 $ curl -i -X POST \


### PR DESCRIPTION
I followed the README.md instructions for setting up a service this morning, and encountered an error when I tried to add a route to the mockbin service:

```bash
$ curl -i -X POST \
>   --url http://localhost:8001/services/mockbin/routes \
>   --data 'paths=/'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   170  100   143  100    27     89     16  0:00:01  0:00:01 --:--:--   106HTTP/1.1 400 Bad Request
Date: Tue, 15 Sep 2020 23:41:55 GMT
Content-Type: application/json; charset=utf-8
Connection: keep-alive
Access-Control-Allow-Origin: *
Server: kong/2.1.3
Content-Length: 143
X-Kong-Admin-Latency: 1371

{"message":"schema violation (paths.1: should start with: \/)","name":"schema violation","fields":{"paths":["should start with: \/"]},"code":2}
```

I fixed this by adding square brackets to the `path` attribute, as described in the [Admin API documentation](https://docs.konghq.com/2.1.x/admin-api/#add-route) and similar to the [official quickstart guide](https://docs.konghq.com/2.1.x/getting-started/configuring-a-service/#2-add-a-route-for-the-service) (this uses `hosts`, not `paths`, but it requires the same notation.

I'm on Windows 10 using the Git Bash shell, 