### PR TITLE
Update provision.sh

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -216,7 +216,7 @@ if [ $KONG_NUM_VERSION -lt 1000 ]; then
   sudo -E apt-get install -qq dnsmasq
 fi
 
-sudo -E apt install -y ./kong.deb
+sudo -E apt-get install -y ./kong.deb
 rm kong.deb
 
 


### PR DESCRIPTION
`apt` doesn't have a stable CLI interface. I changed it to `apt-get`, which will eliminate the issue and prevent the warning while running the script during `vagrant up`.
![Screenshot 2021-01-03 at 21 50 13](https://user-images.githubusercontent.com/2995107/103488555-d7620a00-4e0d-11eb-9ed9-36cf8b472021.png)
