### PR TITLE
chore(*) bump Kong to 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ install:
   - sudo apt-get update && sudo apt-get install -y bridge-utils dnsmasq-base ebtables libvirt-bin libvirt-dev qemu-kvm qemu-utils ruby-dev
 
   # Download Vagrant & Install Vagrant package
-  - sudo wget -nv https://releases.hashicorp.com/vagrant/2.2.7/vagrant_2.2.7_x86_64.deb
-  - sudo dpkg -i vagrant_2.2.7_x86_64.deb
+  - sudo wget -nv https://releases.hashicorp.com/vagrant/2.2.9/vagrant_2.2.9_x86_64.deb
+  - sudo dpkg -i vagrant_2.2.9_x86_64.deb
 
   # Vagrant correctly installed?
   - vagrant --version

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ environment variables:
 
 | name                           | description                                                                                    | default                                                       |
 | ------------------------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `KONG_VERSION`                 | the Kong version number to download and install at the provision step                          | `2.2.1`                                                       |
+| `KONG_VERSION`                 | the Kong version number to download and install at the provision step                          | `2.3.0`                                                       |
 | `KONG_VB_MEM`                  | virtual machine memory (RAM) size *(in MB)*                                                    | `4096`                                                        |
 | `KONG_CASSANDRA`               | the major Cassandra version to use, either `2` or `3`                                          | `3`, or `2` for Kong versions `0.9.x` and older               |
 | `KONG_PATH`                    | the path to mount your local Kong source under the guest's `/kong` folder                      | `./kong`, `../kong`, or nothing. In this order.               |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if ENV["KONG_VERSION"]
     version = ENV["KONG_VERSION"]
   else
-    version = "2.2.1"
+    version = "2.3.0"
   end
 
   if ENV["KONG_CASSANDRA"]


### PR DESCRIPTION
This PR bumps Kong to the latest version and also fixes a problem with Vagrant 2.2.8 on the CI (Nokogiri, one of the dependencies, [failed to install](https://github.com/mitchellh/vagrant-google/issues/238)) so I have bumped the Vagrant version used in CI to 2.2.9, which fixed the issue.