### PR TITLE
chore(vagrant) bump ubuntu to focal

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -87,7 +87,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/ — timesync-set-threshold", 10000]
   end
 
-  config.vm.box = "generic/ubuntu1604"
+  config.vm.box = "generic/ubuntu2004"
 
   if not source == ""
     config.vm.synced_folder source, "/kong"

--- a/provision.sh
+++ b/provision.sh
@@ -121,7 +121,8 @@ fi
 sudo -E apt-get install -qq httpie jq
 sudo -E apt-get install -qq git curl make pkg-config unzip apt-transport-https \
                             language-pack-en libssl-dev m4 cpanminus zlibc \
-                            zlib1g-dev libyaml-dev postgresql-common
+                            zlib1g-dev libyaml-dev postgresql-common build-essential
+
 
 echo "*************************************************************************"
 echo "Installing test tools for Test::Nginx"
@@ -219,14 +220,13 @@ fi
 sudo -E apt-get install -y ./kong.deb
 rm kong.deb
 
-
 if [ -n "$KONG_UTILITIES" ]; then
   echo "*************************************************************************"
   echo "Installing systemtap, stapxx, and openresty-systemtap-toolkit"
   echo "*************************************************************************"
 
   # Install systemtap: https://openresty.org/en/build-systemtap.html
-  sudo -E apt-get install -qq build-essential zlib1g-dev elfutils libdw-dev gettext
+  sudo -E apt-get install -qq zlib1g-dev elfutils libdw-dev gettext
   wget -q http://sourceware.org/systemtap/ftp/releases/systemtap-4.0.tar.gz
   tar -xf systemtap-4.0.tar.gz
   pushd systemtap-4.0/

--- a/provision.sh
+++ b/provision.sh
@@ -72,7 +72,7 @@ if [ $KONG_NUM_VERSION -ge 020000 ]; then
   # update admin to defaults again, but on 0.0.0.0 instead of 127.0.0.1
   KONG_ADMIN_LISTEN="0.0.0.0:8001 reuseport backlog=16384, 0.0.0.0:8444 http2 ssl reuseport backlog=16384"
   # use Xenial now instead of Bionic
-  KONG_DOWNLOAD_URL="https://download.konghq.com/gateway-2.x-ubuntu-xenial/pool/all/k/kong/kong_${KONG_VERSION}_amd64.deb"
+  KONG_DOWNLOAD_URL="https://download.konghq.com/gateway-2.x-ubuntu-focal/pool/all/k/kong/kong_${KONG_VERSION}_amd64.deb"
 fi
 
 sudo chown -R vagrant /usr/local


### PR DESCRIPTION
Currently in use base image is for Ubuntu 16.04 - which is currently in Extended Security maintenance. This PR updates the base to Ubuntu 20.04, the latest LTS release.